### PR TITLE
version info in makefile

### DIFF
--- a/main/version.h
+++ b/main/version.h
@@ -21,7 +21,10 @@
 
 namespace particle {
 
-const char* const FIRMWARE_VERSION_STRING = "0.0.2";
-const uint16_t FIRMWARE_MODULE_VERSION = 2;
+#define xstr(x) str(x)
+#define str(x) #x
+
+const char* const FIRMWARE_VERSION_STRING = xstr(ARGON_FIRMWARE_VERSION);
+const uint16_t FIRMWARE_MODULE_VERSION = ARGON_FIRMWARE_MODULE_VERSION;
 
 } // particle

--- a/moduleinfo.mk
+++ b/moduleinfo.mk
@@ -1,5 +1,6 @@
 include macros.mk
 include verbose.mk
+include version.mk
 
 CRC = crc32
 XXD = xxd
@@ -42,13 +43,13 @@ START_ADDR=00000000	 # not used
 END_ADDR=00000000	 # not used
 NCP_ID=21			 # 33 (see hal/src/hRF52840/platform_ncp.h)
 RESERVED2=00		 # not used
-MODULE_VERSION=0100	 # 0x0001
+MODULE_VERSION_LE=0100	 # 0x0001
 PLATFORM_ID=0C00	 # 12 - Argon
 MODULE_FUNCTION=03   # mono firmware
 MODULE_INDEX=00		 # not used with mono firmware
 DEPENDENCY=00000000
 DEPENDENCY2=00000000
-MODULE_PREFIX=$(START_ADDR)$(END_ADDR)$(NCP_ID)$(RESERVED2)$(MODULE_VERSION)$(PLATFORM_ID)$(MODULE_FUNCTION)$(MODULE_INDEX)$(DEPENDENCY)$(DEPENDENCY2)
+MODULE_PREFIX=$(START_ADDR)$(END_ADDR)$(NCP_ID)$(RESERVED2)$(MODULE_VERSION_LE)$(PLATFORM_ID)$(MODULE_FUNCTION)$(MODULE_INDEX)$(DEPENDENCY)$(DEPENDENCY2)
 
 # regular MCU firmware has the product ID stored before the suffix
 # since this has little relevance here we don't bother	

--- a/version.mk
+++ b/version.mk
@@ -1,0 +1,9 @@
+# module version as a C literal
+MODULE_VERSION?=1
+# module version as hex string in little endian format
+MODULE_VERSION_LE?=0100
+
+FIRMWARE_VERSION?=0.0.2
+
+CXXFLAGS += -DARGON_FIRMWARE_VERSION=$(FIRMWARE_VERSION)
+CXXFLAGS += -DARGON_FIRMWARE_MODULE_VERSION=$(MODULE_VERSION)


### PR DESCRIPTION
moves the version information into the makefile so that it can be used to build the module info.