### PR TITLE
ncp: disables softap by default

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -104,6 +104,7 @@ int main() {
 
     CHECK(nvsInitialize());
     CHECK(atInitialize());
+    CHECK(miscInitialize());
 
     LOG(INFO, "Initialized");
 


### PR DESCRIPTION
By default, ESP32-AT will enable SoftAP and ESP32 will be broadcasting an unprotected SSID. This PR disables that.